### PR TITLE
Return the full path after the package name

### DIFF
--- a/flipper-realm-android/src/main/java/com/kgurgul/flipper/RealmDatabaseDriver.kt
+++ b/flipper-realm-android/src/main/java/com/kgurgul/flipper/RealmDatabaseDriver.kt
@@ -21,7 +21,6 @@ import com.facebook.flipper.plugins.databases.DatabaseDescriptor
 import com.facebook.flipper.plugins.databases.DatabaseDriver
 import io.realm.Realm
 import io.realm.RealmConfiguration
-import java.io.File
 
 /**
  * Flipper driver for [Realm] database
@@ -33,7 +32,7 @@ class RealmDatabaseDriver(
 
     override fun getDatabases(): List<RealmDatabaseDescriptor> {
         return realmDatabaseProvider.getRealmConfigurations().map {
-            RealmDatabaseDescriptor(it)
+            RealmDatabaseDescriptor(it, context.packageName)
         }
     }
 
@@ -105,13 +104,17 @@ class RealmDatabaseDriver(
         databaseDescriptor: RealmDatabaseDescriptor,
         query: String
     ): DatabaseExecuteSqlResponse? {
+        context
         return null
     }
 
     class RealmDatabaseDescriptor(
-        val realmConfiguration: RealmConfiguration
+        val realmConfiguration: RealmConfiguration,
+        private val packageName: String
     ) : DatabaseDescriptor {
 
-        override fun name(): String = File(realmConfiguration.path).name
+        // Return the full path after the package name, useful if multiple instances of Realm
+        // have the same name, but not the same location.
+        override fun name() = "…" + realmConfiguration.path.substringAfterLast(packageName)
     }
 }


### PR DESCRIPTION
Return the full path after the package name for the database name.

Useful if multiple instance of Realm have the same name, for instance in a multi-account app, where each account will have its own database instance.

|Before|After|
|-|-|
|<img width="818" alt="image" src="https://user-images.githubusercontent.com/3940906/173804679-4962745a-8dec-4cf4-bba9-ba234481d03e.png">|<img width="812" alt="image" src="https://user-images.githubusercontent.com/3940906/173804482-20900c02-0014-4b84-abc6-10e45a8c06e8.png">|