### PR TITLE
Add support to sort columns which can be sorted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Open Flipper app and enable Database plugin
 Features
 ========
 * Displaying data from Realm database
+* Sort data by columns, for the types `RealmFieldType.BOOLEAN`, `RealmFieldType.INTEGER`, `RealmFieldType.FLOAT`, `RealmFieldType.DOUBLE`, `RealmFieldType.STRING`, `RealmFieldType.DATE`.
 * Displaying database structure
 
-Currently it is not possible to sort data by columns or modify database from Flipper.
+Currently it is not possible to modify database from Flipper.
 
 License
 -------

--- a/flipper-realm-android/src/main/java/com/kgurgul/flipper/RealmDatabaseDriver.kt
+++ b/flipper-realm-android/src/main/java/com/kgurgul/flipper/RealmDatabaseDriver.kt
@@ -86,6 +86,8 @@ class RealmDatabaseDriver(
         val values = RealmHelper.getRows(
             databaseDescriptor.realmConfiguration,
             table,
+            order,
+            reverse,
             start,
             count
         )


### PR DESCRIPTION
Replacement for closed PR #3 . It allows to sort only sortable columns from Realm. Trying to sort not sortable column will just have the effect to reset any other sorting.

Demo from the sample app:

![SortDb](https://user-images.githubusercontent.com/3940906/173807419-d620727d-78a5-4287-a1e1-e305907368c7.gif)
